### PR TITLE
fix: make user pill in chat full width

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -129,7 +129,7 @@ const Home: NextPage = () => {
                       : msg.author === "user"
                       ? "badge-secondary"
                       : ""
-                  } badge-lg text-sm font-semibold mr-4`}
+                  } badge-lg text-sm font-semibold mr-4 min-w-max`}
                 >
                   {msg.author === "bot"
                     ? "Athena but better"


### PR DESCRIPTION
Makes the user pill in the chat full width to accommodate users on a smaller screen where the message overflows and the text in the pill overflows too. This change makes the pill similar to the timestamp.